### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/contracts/flow/REVV.cdc
+++ b/contracts/flow/REVV.cdc
@@ -73,7 +73,7 @@ access(all) contract REVV: FungibleToken {
                   externalURL: MetadataViews.ExternalURL("https://motorverse.com"),
                   logos: medias,
                   socials: {
-                      "twitter": MetadataViews.ExternalURL("https://twitter.com/REVV_Token")
+                      "twitter": MetadataViews.ExternalURL("https://x.com/REVV_Token")
                   }
               )
           case Type<FungibleTokenMetadataViews.FTVaultData>():


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.